### PR TITLE
CSVFiles: make `delim` a keyword argument in `load`

### DIFF
--- a/src/CSVFiles.jl
+++ b/src/CSVFiles.jl
@@ -38,11 +38,19 @@ end
 
 Base.showable(::MIME"text/html", source::CSVStream) = true
 
-function fileio_load(f::FileIO.File{FileIO.format"CSV"}, delim=','; args...)
+function fileio_load(f::FileIO.File{FileIO.format"CSV"}, delim::Char; args...)
     return CSVFile(f.filename, delim, args)
 end
 
-function fileio_load(f::FileIO.File{FileIO.format"TSV"}, delim='\t'; args...)
+function fileio_load(f::FileIO.File{FileIO.format"CSV"}; delim=',', args...)
+    return CSVFile(f.filename, delim, args)
+end
+
+function fileio_load(f::FileIO.File{FileIO.format"TSV"}, delim::Char; args...)
+    return CSVFile(f.filename, delim, args)
+end
+
+function fileio_load(f::FileIO.File{FileIO.format"TSV"}; delim='\t', args...)
     return CSVFile(f.filename, delim, args)
 end
 


### PR DESCRIPTION
See issue #16.

`load` accepts `delim` as a keyword argument for CSV files and/or TSV files. The delimiting character may also be specified as the second positional argument (as before).

Tests:
```julia
load(File(format"CSV", "../../data/Iris/iris.data"))
# ok

load(File(format"CSV", "../../data/Iris/iris.data"), ',')
#ok

load(File(format"CSV", "../../data/Iris/iris.data"), delim=',')
#ok

load(File(format"CSV", "../../data/Iris/iris.data"), skiplines_begin=3, header_exists=false)
# ok

load(File(format"CSV", "../../data/Iris/iris.data"), delim=',', skiplines_begin=3, header_exists=false)
# ok

load(File(format"CSV", "../../data/Iris/iris.data"), skiplines_begin=3, header_exists=false, delim=',')
# ok
# similar tests with a file containing ';' as a separator are successful, too

# tsv
load("../../data/Iris/iris.tsv")
# ok

load("../../data/Iris/iris.tsv", '\t')
# ok

load("../../data/Iris/iris.tsv", delim='\t')
# ok
```

When `load` is called with a stream as first argument, `delim` is accepted as a keyword argument. However, I could not extract data from a stream obtained with `open`:
``` julia
     julia> csio = open("../../data/Iris/iris.csv")
     IOStream(<file ../../data/Iris/iris.csv>)

     julia> csvs = load(Stream(format"CSV", csio), skiplines_begin=3, header_exists=false);

     julia> df = DataFrame(csvs)
     ERROR: MethodError: no method matching String(::Ptr{UInt8}, ::Int64)
     Stacktrace:
      [1] #csvread#17(::Base.Iterators.Pairs{Symbol,Integer,Tuple{Symbol,Symbol},NamedTuple{(:skiplines_begin, :header_exists),Tuple{Int64,Bool}}}, ::Function, ::IOStream, ::Char) at /home/nepomuk/.julia/packages/TextParse/WFgcL/src/csv.jl:80
      [2] (::getfield(TextParse, Symbol("#kw##csvread")))(::NamedTuple{(:skiplines_begin, :header_exists),Tuple{Int64,Bool}}, ::typeof(TextParse.csvread), ::IOStream, ::Char) at ./none:0
      [3] getiterator(::CSVFiles.CSVStream) at /home/nepomuk/projekte/run/julia/CSVFiles/src/CSVFiles.jl:93
      [4] DataFrame(::CSVFiles.CSVStream) at /home/nepomuk/.julia/packages/DataFrames/VC5qi/src/other/tables.jl:22
      [5] top-level scope at none:0
```