### PR TITLE
Add support for savestreaming method, take 2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,9 +16,10 @@ TextParse = "e0df1984-e451-5cb5-8b61-797a481e67e3"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 
 [targets]
-test = ["Test"]
+test = ["Test", "DataFrames"]
 
 [compat]
 CodecZlib = "≥ 0.5.2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -212,8 +212,31 @@ end
         @test showable("text/html", x2) == true
         @test showable("application/vnd.dataresource+json", x2) == true        
     end
-
     
+end
+
+@testset "savestreaming" begin
+    using DataFrames
+
+    df = DataFrame(A = 1:2:1000, B = repeat(1:10, inner=50), C = 1:500)
+    df1 = df[1:5, :]
+    df2 = df[6:10, :]
+
+    # Test both csv and tsv formats
+    for ext in ("csv", "tsv")
+        fname = "output.$ext"
+        s = savestreaming(fname, df1)
+        savestreaming(s, df2)
+        savestreaming(s, df2)   # add this slice twice
+        close(s)
+    
+        new_df = DataFrame(load(fname))
+        @test new_df[1:5,:]   == df1
+        @test new_df[6:10,:]  == df2
+        @test new_df[11:15,:] == df2
+
+        rm(fname)
+    end
 end
 
 end # Outer-most testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -226,8 +226,8 @@ end
     for ext in ("csv", "tsv")
         fname = "output.$ext"
         s = savestreaming(fname, df1)
-        savestreaming(s, df2)
-        savestreaming(s, df2)   # add this slice twice
+        write(s, df2)
+        write(s, df2)   # add this slice twice
         close(s)
     
         new_df = DataFrame(load(fname))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -92,7 +92,6 @@ end
         output_filename4 = tempname() * ".csv"
 
         try
-            @show output_filename4
             array |> save(output_filename4, quotechar=nothing)
 
         finally


### PR DESCRIPTION
Replaces #53.

The documentation for the API in FileIO.jl is really incomplete, but I think this PR is how it should be done (I tracked down some packages from the person who initially added this feature to FileIO.jl and looked how they are doing it).

The API from a user point of view is:
```julia
s = savestreaming(fname, df1)
# OR
s = savestreaming(fname)
# If one doesn't want to write any data at this point.

write(s, df2)
write(s, df2)

close(s)
```

@lrennels, can you adapt your code to this new API, test whether things work, and then I'll merge this PR here?